### PR TITLE
Removing all special characters in address

### DIFF
--- a/server/controllers/api-controller.js
+++ b/server/controllers/api-controller.js
@@ -167,7 +167,7 @@ controller.apiQueries = (req, res, next) => {
         // simpler reference to the location for the current element
         const location = electionData.pollingLocations[i].address;
         // appending together the first line of the address with the city and state
-        let currentAddress = `${location.line1} ${location.city} ${location.state}`;
+        let currentAddress = `${location.line1} ${location.city} ${location.state}`.replace(/[\W\s]/g,'');                                    
         // encoding the address so we can use it in the query URI
         currentAddress = encodeURI(currentAddress);
         // saving the query URI for our fetch request
@@ -191,7 +191,7 @@ controller.apiQueries = (req, res, next) => {
         // simpler reference to the location for the current element
         const location = electionData.earlyVoteSites[i].address;
         // appending together the first line of the address with the city and state
-        let currentAddress = `${location.line1} ${location.city} ${location.state}`;
+        let currentAddress = `${location.line1} ${location.city} ${location.state}`.replace(/[\W\s]/g,'');
         // encoding the address so we can use it in the query URI
         currentAddress = encodeURI(currentAddress);
         // saving the query URI for our fetch request
@@ -215,7 +215,7 @@ controller.apiQueries = (req, res, next) => {
         // simpler reference to the location for the current element
         const location = electionData.dropOffLocations[i].address;
         // appending together the first line of the address with the city and state
-        let currentAddress = `${location.line1} ${location.city} ${location.state}`;
+        let currentAddress = `${location.line1} ${location.city} ${location.state}`.replace(/[\W\s]/g,'');
         // encoding the address so we can use it in the query URI
         currentAddress = encodeURI(currentAddress);
         // saving the query URI for our fetch request


### PR DESCRIPTION
Implementing Chris' fix to use regex to remove anything that's not a whitespace or an alphanumeric character.

This was causing issues when passing into the Google Maps API because the `#` (and potentially other characters) caused an issue in the get request URL.